### PR TITLE
Make Python 2.6 working again.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-#  - "2.6" not supported (at the moment, because unittest's "assertRegex")
+  - "2.6"
   - "2.7"
   - "pypy"
   - "3.2"
@@ -9,6 +9,8 @@ python:
 install:
     pip install coveralls
 
+before_script:
+  - '[ "${TRAVIS_PYTHON_VERSION}" = "2.6" ] && pip install --use-mirrors unittest2 || /bin/true'
 script:
     coverage run --source=gitshelve setup.py test
 after_success:

--- a/test/test_gitshelve.py
+++ b/test/test_gitshelve.py
@@ -5,7 +5,10 @@ import re
 import shutil
 import sys
 import tempfile
-import unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 try:
     from StringIO import StringIO


### PR DESCRIPTION
I think using unittest2 from PyPI is a perfectly acceptable workaround
for unittests to work.
